### PR TITLE
Update string.py

### DIFF
--- a/workon/utils/string.py
+++ b/workon/utils/string.py
@@ -1,6 +1,7 @@
 import unicodedata, re, json
 from django.utils.encoding import force_str, force_text
-from django.utils.text import Truncator, slugify as django_slugify, mark_safe
+from django.utils.text import Truncator, slugify as django_slugify
+from django.utils.html import mark_safe
 from django.utils.encoding import force_text
 from django.utils import six
 


### PR DESCRIPTION
The import mark_safe from django.utils.text is no longuer working with django 2.2.

The import mark_safe from django.utils.html could be done instead

Thanks for making the change.

Regards,

Anhackers